### PR TITLE
Prevent duplicate inverse connections and require message sender membership

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -131,6 +131,9 @@ CREATE TABLE connections (
   UNIQUE (requester_id, addressee_id)
 );
 
+CREATE UNIQUE INDEX uniq_connections_unordered_pair
+  ON connections (LEAST(requester_id, addressee_id), GREATEST(requester_id, addressee_id));
+
 CREATE TABLE follows (
   follower_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   followee_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -255,6 +258,10 @@ CREATE TABLE messages (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
   sender_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_messages_conversation_sender_member
+    FOREIGN KEY (conversation_id, sender_user_id)
+    REFERENCES conversation_members(conversation_id, user_id)
+    ON DELETE RESTRICT,
   body TEXT NOT NULL,
   attachments JSONB NOT NULL DEFAULT '[]'::jsonb,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
### Motivation
- Prevent creation of duplicate / conflicting connection edges between two users that can appear as `A→B` and `B→A` and cause double-counting or inconsistent statuses. 
- Ensure message integrity by guaranteeing that a message `sender_user_id` is actually a member of the referenced `conversation_id` to avoid unauthorized message injection.

### Description
- Added a unique functional index `uniq_connections_unordered_pair` on `connections` using `LEAST(requester_id, addressee_id)` and `GREATEST(requester_id, addressee_id)` to enforce unordered-pair uniqueness for user connections. 
- Kept the existing `UNIQUE (requester_id, addressee_id)` and `CHECK (requester_id <> addressee_id)` but added the unordered index to guarantee a single canonical edge for any pair. 
- Added a composite foreign key constraint `fk_messages_conversation_sender_member` on `messages` linking `(conversation_id, sender_user_id)` to `conversation_members(conversation_id, user_id)` with `ON DELETE RESTRICT` to ensure senders are conversation members.

### Testing
- Ran `git diff --check` to validate patch cleanliness and it completed successfully. 
- Ran `git status --short` to confirm working-tree changes and it reported the expected staged modification. 
- Reviewed the diff with `git diff -- database/schema.sql` to confirm only the intended index and constraint were added and the file looks correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c06640ac8320b94cc78859f69fe8)